### PR TITLE
稍微优化一下

### DIFF
--- a/contents/libextobjc/如何在 Objective-C 的环境下实现 defer.md
+++ b/contents/libextobjc/如何在 Objective-C 的环境下实现 defer.md
@@ -111,9 +111,14 @@ __strong ext_cleanupBlock_t ext_exitBlock_19 __attribute__((cleanup(ext_executeC
 这里，我们分几个部分来分析上面的代码片段是如何实现 `defer` 的功能的：
 
 1. `ext_keywordify` 也是一个宏定义，它通过添加在宏之前添加 `autoreleasepool {}` 强迫 `onExit` 前必须加上 `@` 符号。
-
+    这里作者用 DEBUG 宏区分了开发和生产环境, 我们可以看到, 生产环境用的是 try catch, 目的是为了避免插入过多不必要的自动释放池
+    
     ```objectivec
+    #if defined(DEBUG) && !defined(NDEBUG)
     #define ext_keywordify autoreleasepool {}
+    #else
+    #define ext_keywordify try {} @catch (...) {}
+    #endif
     ```
 
 2. `ext_cleanupBlock_t` 是一个类型：


### PR DESCRIPTION
这里作者用 DEBUG 宏区分了开发和生产环境, 我们可以看到, 生产环境用的是 try catch, 目的是为了避免插入过多不必要的自动释放池

#if defined(DEBUG) && !defined(NDEBUG)
#define ext_keywordify autoreleasepool {}
#else
#define ext_keywordify try {} @catch (...) {}
#endif